### PR TITLE
Add missing uhashlib back in

### DIFF
--- a/MicroPython_BUILD/components/micropython/esp32/mpconfigport.h
+++ b/MicroPython_BUILD/components/micropython/esp32/mpconfigport.h
@@ -262,6 +262,7 @@ extern const struct _mp_obj_module_t mp_module_ota;
     { MP_OBJ_NEW_QSTR(MP_QSTR_machine),  (mp_obj_t)&mp_module_machine }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_network),  (mp_obj_t)&mp_module_network }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_ymodem),   (mp_obj_t)&mp_module_ymodem }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_uhashlib), (mp_obj_t)&mp_module_uhashlib }, \
 	BUILTIN_MODULE_DISPLAY \
 	BUILTIN_MODULE_CURL \
 	BUILTIN_MODULE_SSH \


### PR DESCRIPTION
Add missing uhashlib back in, hashlib will not be available anymore
see issue in main esp32 port: [#178 main esp32](https://github.com/micropython/micropython-esp32/issues/178)
or pull request in main port: [#179 main esp32](https://github.com/micropython/micropython-esp32/pull/179)

Could not run uasyncio as uhashlib was missing. This fixed it.